### PR TITLE
Update revChatGPT version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 graia-ariadne==0.10.0
-revChatGPT>=0.0.44
+revChatGPT==0.0.44
 Pillow>=9.3.0


### PR DESCRIPTION
目前 revChatGPT 0.0.47 版本已经移除了 `AsyncChatbot, generate_uuid` 两个API

只剩下了 `Chatbot`


https://github.com/acheong08/ChatGPT/blob/97b324c09133d6175a9538496e9302e397bbc547/src/revChatGPT/ChatGPT.py#L24


执行

https://github.com/lss233/chatgpt-mirai-qq-bot/blob/2fbafaacab44f492717f6b3b7137a1d1bf44dc11/chatbot.py#L1

```
from revChatGPT.revChatGPT import AsyncChatbot, generate_uuid
```
会 raise `revChatGPT.revChatGPT`  module not found 

我看了下 `ChatGPT` 内部没有很大变化，不过在迁移代码之前，建议先固定pip install 的 revChatGPT 版本

------

哦对了，非常感谢你们非常有帮助的代码！！🥳🥳🥳🥳🥳
