### PR TITLE
add missed requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 graia-ariadne>=0.10.3
+undetected_chromedriver>=3.1.7
+selenium>=4.7.2
+tls_client>=0.1.7
+2captcha-python>=1.1.3
 revChatGPT>=0.1.1
 Pillow>=9.3.0


### PR DESCRIPTION
revChatGPT１.０之后的新版本删除了tls_clinet等依赖，导致报错no module named tls_client。因此需要将其去掉的依赖加到requirement.txt中。
经测试，按当前requirement.txt会安装revChatGPT最新1.1.0版本，可以正常运行。