### PR TITLE
1、修复编码错误；2、修复图片过长

### DIFF
--- a/assets/texttoimg/css/default.css
+++ b/assets/texttoimg/css/default.css
@@ -379,7 +379,6 @@ body {
     line-height: 1.6rem;
     letter-spacing: 0;
     margin: 0;
-    overflow-x: hidden
 }
 
 img {

--- a/utils/text_to_img.py
+++ b/utils/text_to_img.py
@@ -331,7 +331,7 @@ async def text_to_image(text):
             temp_jpg_filename = temp_jpg_file.name
             temp_jpg_file.close()
 
-        temp_html_file = NamedTemporaryFile(mode='w', suffix='.html')
+        temp_html_file = NamedTemporaryFile(mode='w', suffix='.html', encoding='utf-8')
         temp_html_filename = temp_html_file.name
         imgkit_config = imgkit.config(wkhtmltoimage=config.text_to_image.wkhtmltoimage)
         with StringIO(html) as input_file:


### PR DESCRIPTION
1、将文件编码改为UTF-8，以修复UnicodeEncodeError

例子：
用户：`将“忧郁的乌龟”分别翻译为繁体中文、日文、韩文、英文`
机器人理想状态：
```
繁体中文：憂鬱的烏龜
日文：憂鬱なカメ
韓文：우울한 거북이
英文：Melancholy Turtle
```
实际报错：`UnicodeEncodeError: 'gbk' codec can't encode character '\uc6b0' in position 5067:`
然后回退到备用模式

2、wkhtmltoimage似乎对overflow-x属性兼容不好，在Windows上会使得图片过长，且中文越多图片越长
https://github.com/lss233/chatgpt-mirai-qq-bot/issues/286