### PR TITLE
使HTML图片渲染模式下可调节文字大小和字体

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ always = true
 # 是否默认开启，设置后所有的消息默认以图片发送，减小风控概率  
 default = true
 
-# [备用模式]字体大小
+# 字体大小
 font_size = 30
 
-# [备用模式]图片宽度
+# 图片宽度
 width = 700
 
-# [备用模式]字体
+# 字体
 font_path = "fonts/sarasa-mono-sc-regular.ttf" 
 
 # [备用模式]起始点 X

--- a/assets/texttoimg/css/default.css
+++ b/assets/texttoimg/css/default.css
@@ -1,5 +1,5 @@
 body {
-    font-family: "Microsoft Yahei",Helvetica,arial,sans-serif;
+    font-family: "Custom Font","Microsoft Yahei",Helvetica,arial,sans-serif;
     font-size: 1rem;
     line-height: 1.6;
     padding-top: 10px;
@@ -366,7 +366,6 @@ code {
 }
 
 body {
-    font-family: "JetBrains Mono",sans-serif!important;
     color: var(--drake-text-color);
     -webkit-font-feature-settings: "liga"on,"calt"on;
     -webkit-font-smoothing: subpixel-antialiased;

--- a/assets/texttoimg/css/default.css
+++ b/assets/texttoimg/css/default.css
@@ -1,6 +1,6 @@
 body {
     font-family: "Microsoft Yahei",Helvetica,arial,sans-serif;
-    font-size: 14px;
+    font-size: 1rem;
     line-height: 1.6;
     padding-top: 10px;
     padding-bottom: 10px;
@@ -49,7 +49,7 @@ h1:hover a.anchor,h2:hover a.anchor,h3:hover a.anchor,h4:hover a.anchor,h5:hover
     background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA09pVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoMTMuMCAyMDEyMDMwNS5tLjQxNSAyMDEyLzAzLzA1OjIxOjAwOjAwKSAgKE1hY2ludG9zaCkiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OUM2NjlDQjI4ODBGMTFFMTg1ODlEODNERDJBRjUwQTQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OUM2NjlDQjM4ODBGMTFFMTg1ODlEODNERDJBRjUwQTQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo5QzY2OUNCMDg4MEYxMUUxODU4OUQ4M0REMkFGNTBBNCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo5QzY2OUNCMTg4MEYxMUUxODU4OUQ4M0REMkFGNTBBNCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PsQhXeAAAABfSURBVHjaYvz);
     text-decoration:none;
 }
-h1 tt,h1 code{font-size:inherit}h2 tt,h2 code{font-size:inherit}h3 tt,h3 code{font-size:inherit}h4 tt,h4 code{font-size:inherit}h5 tt,h5 code{font-size:inherit}h6 tt,h6 code{font-size:inherit}h1{font-size:28px;color:#2B3F52}h2{font-size:24px;border-bottom:1px solid#DDE4E9;color:#2B3F52}h3{font-size:18px;color:#2B3F52}h4{font-size:16px;color:#2B3F52}h5{font-size:14px;color:#2B3F52}h6{color:#2B3F52;font-size:14px}p,blockquote,ul,ol,dl,li,table,pre{margin:15px 0;color:#516272}hr{background:transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC)repeat-x 0 0;
+h1 tt,h1 code{font-size:inherit}h2 tt,h2 code{font-size:inherit}h3 tt,h3 code{font-size:inherit}h4 tt,h4 code{font-size:inherit}h5 tt,h5 code{font-size:inherit}h6 tt,h6 code{font-size:inherit}h1{font-size:1.75rem;color:#2B3F52}h2{font-size:1.5rem;border-bottom:1px solid#DDE4E9;color:#2B3F52}h3{font-size:1.125rem;color:#2B3F52}h4{font-size:1rem;color:#2B3F52}h5{font-size:0.875rem;color:#2B3F52}h6{color:#2B3F52;font-size:0.875rem}p,blockquote,ul,ol,dl,li,table,pre{margin:15px 0;color:#516272}hr{background:transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC)repeat-x 0 0;
     border: 0 none;
     color: #cccccc;
     height: 4px;
@@ -106,7 +106,7 @@ dl {
 }
 
 dl dt {
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: bold;
     font-style: italic;
     padding: 0;
@@ -302,7 +302,7 @@ pre code {
 .highlight pre {
     background-color: #f8f8f8;
     border: 1px solid#cccccc;
-    font-size: 13px;
+    font-size: 0.8125rem;
     line-height: 19px;
     overflow: auto;
     padding: 6px 10px;
@@ -312,7 +312,7 @@ pre code {
 pre {
     background-color: #f8f8f8;
     border: 1px solid#e9e9e9;
-    font-size: 13px;
+    font-size: 0.8125rem;
     line-height: 19px;
     overflow: auto;
     padding: 6px 10px
@@ -363,10 +363,6 @@ code {
     --drake-accent: #e95f59;
     --drake-highlight: #d63200;
     --drake-text-color: #000000
-}
-
-html {
-    font-size: 12px
 }
 
 body {
@@ -685,10 +681,6 @@ table tr th:last-child,table tr td:last-child {
 }
 
 @media print {
-    html {
-        font-size: 12px
-    }
-
     table,pre {
         page-break-inside: avoid
     }
@@ -829,7 +821,7 @@ header,.context-menu,.megamenu-content,footer {
 }
 
 .typora-quick-open-item-path {
-    font-size: 10px;
+    font-size: 0.625rem;
     text-overflow: ellipsis;
     white-space: nowrap
 }

--- a/assets/texttoimg/template.html
+++ b/assets/texttoimg/template.html
@@ -20,6 +20,9 @@
         .MathJax {
             font-size: 25px !important;
         }
+        html {
+            font-size: {font_size_texttoimg}px;
+        }
     </style>
 </head>
 

--- a/assets/texttoimg/template.html
+++ b/assets/texttoimg/template.html
@@ -23,6 +23,10 @@
         html {
             font-size: {font_size_texttoimg}px;
         }
+        @font-face {
+            font-family: "Custom Font";
+            src: url("{font_path_texttoimg}");
+        }
     </style>
 </head>
 

--- a/utils/text_to_img.py
+++ b/utils/text_to_img.py
@@ -318,13 +318,16 @@ async def text_to_image(text):
 
         asset_folder = os.path.join(os.getcwd(), 'assets', 'texttoimg')
 
+        font_path = os.path.join(os.getcwd(), config.text_to_image.font_path)
+
         # 输出html到字符串io流
         with StringIO() as output_file:
             # 填充正文
             html = template_html.replace('{path_texttoimg}', pathlib.Path(asset_folder).as_uri()) \
                 .replace("{qrcode}", await get_qr_data(text)) \
                 .replace("{content}", content) \
-                .replace("{font_size_texttoimg}", str(config.text_to_image.font_size))
+                .replace("{font_size_texttoimg}", str(config.text_to_image.font_size)) \
+                .replace("{font_path_texttoimg}", pathlib.Path(font_path).as_uri())
             output_file.write(html)
 
             # 创建临时jpg文件

--- a/utils/text_to_img.py
+++ b/utils/text_to_img.py
@@ -323,7 +323,8 @@ async def text_to_image(text):
             # 填充正文
             html = template_html.replace('{path_texttoimg}', pathlib.Path(asset_folder).as_uri()) \
                 .replace("{qrcode}", await get_qr_data(text)) \
-                .replace("{content}", content)
+                .replace("{content}", content) \
+                .replace("{font_size_texttoimg}", str(config.text_to_image.font_size))
             output_file.write(html)
 
             # 创建临时jpg文件


### PR DESCRIPTION
1、通过定义REM的字体大小来调节全部文本大小，将CSS中font-size全部改为rem定义
2、在template.html中新增一个font-face来接受自定义字体，当字体不存在时仍能使用系统字体
3、更改了readme中关于图片模式的描述（包括新支持的文字大小和字体，以及原来的代码图片宽度是会影响HTML图片渲染模式的图片大小的，并非备用模式）