### PR TITLE
1、Bing会话限制已提升至15条 2、更新上游修复Bing无限结束会话

### DIFF
--- a/adapter/ms/bing.py
+++ b/adapter/ms/bing.py
@@ -40,7 +40,7 @@ class BingAdapter(BotAdapter):
 
     async def ask(self, prompt: str) -> Generator[str, None, None]:
         self.count = self.count + 1
-        remaining_conversations = f'剩余回复数：{self.count} / 10:\n'
+        remaining_conversations = f'剩余回复数：{self.count} / 15:\n'
         parsed_content = ''
         try:
             async for final, response in self.bot.ask_stream(prompt=prompt,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pygments~=2.10.0
 imgkit~=1.2.2
 qrcode~=7.4.2
 openai~=0.26.5
-EdgeGPT==0.0.55
+EdgeGPT==0.0.56.2
 aiohttp~=3.8.3
 selenium~=4.8.0
 OpenAIAuth~=0.3.2


### PR DESCRIPTION
Bing 宣布 Bing Chat 单个会话里的连续提问次数提升至 15 条，每个账户每天最多可以提问 150 条

上游依赖EdgeGPT修复了一个导致`KeyError: 'messages'`的错误