### PR TITLE
fix:修复映射表校验、后缀重复

### DIFF
--- a/utils/text_to_speech.py
+++ b/utils/text_to_speech.py
@@ -21,7 +21,7 @@ async def get_tts_voice(elem, conversation_context) -> Optional[Voice]:
     if "vits" == config.text_to_speech.engine:
         from utils.vits_tts import VitsAPI
         if config.mirai or config.onebot:
-            output_file.name = output_file.name + ".silk"
+            output_file.name = output_file.name.split(".")[0] + ".silk"
         if await VitsAPI.vits_api(str(elem), output_file.name):
             logger.debug(f"[TextToSpeech] 语音转换完成 - {output_file.name} - {conversation_context.session_id}")
             return Voice(path=output_file.name)

--- a/utils/vits_tts.py
+++ b/utils/vits_tts.py
@@ -23,10 +23,11 @@ class VitsAPI:
         async with ClientSession(timeout=ClientTimeout(total=config.vits.timeout)) as session:
             async with session.post(url=url) as res:
                 json_array = await res.json()
+                vits_list = json_array["VITS"]
 
                 try:
                     integer_number = int(config.text_to_speech.default)
-                    result = self.check_id_exists(json_array, integer_number)
+                    result = self.check_id_exists(vits_list, integer_number)
                 except ValueError:
                     logger.error("vits引擎中音色只能为纯数字")
                     return None


### PR DESCRIPTION
你好！我在代码中修复了以下问题：
1、`output_file.name`获取到的是文件的完整名称，直接加".silk"导致后缀重复
2、由于映射表更新，在此修复了获取vits角色id失败的问题