### PR TITLE
修复图片模式下文字超出设定宽度

### DIFF
--- a/assets/texttoimg/css/default.css
+++ b/assets/texttoimg/css/default.css
@@ -6,7 +6,8 @@ body {
     padding-bottom: 10px;
     background-color: white;
     padding: 30px;
-    color: #516272
+    color: #516272;
+    word-break: break-all
 }
 
 body>*:first-child {


### PR DESCRIPTION
原代码效果：
![test](https://user-images.githubusercontent.com/92856393/230695349-6801b723-d0a5-46b5-9183-24bd6de75526.png)

修改后效果：
![test](https://user-images.githubusercontent.com/92856393/230695371-f4841b41-bcf3-48d7-a05b-e170ca33a463.png)
