### PR TITLE
针对stable diffusion api有账号密码的情况做出相应完善

### DIFF
--- a/config.py
+++ b/config.py
@@ -454,6 +454,8 @@ class SDWebUI(BaseModel):
     n_iter: int = 1
     cfg_scale: float = 7.5
     restore_faces: bool = False
+    authorization: str = ''
+    """登录api的账号:密码"""
 
     timeout: float = 10.0
     """超时时间"""

--- a/drawing/sdwebui.py
+++ b/drawing/sdwebui.py
@@ -1,5 +1,5 @@
 from typing import List
-
+import base64
 import httpx
 from graia.ariadne.message.element import Image
 
@@ -7,7 +7,24 @@ from constants import config
 from .base import DrawingAPI
 
 
+def basic_auth_encode(authorization: str) -> str:
+
+    authorization_bytes = authorization.encode('utf-8')
+    encoded_authorization = base64.b64encode(authorization_bytes).decode('utf-8')
+    return f"Basic {encoded_authorization}"
+
+def init_authorization():
+    if config.sdwebui.authorization != '':
+        return basic_auth_encode(config.sdwebui.authorization)
+    else:
+        return ''
+
 class SDWebUI(DrawingAPI):
+
+
+    headers = {
+        "Authorization": f"{init_authorization()}"
+    }
 
     async def text_to_img(self, prompt):
         payload = {
@@ -33,7 +50,7 @@ class SDWebUI(DrawingAPI):
                 payload[key] = value
 
         resp = await httpx.AsyncClient(timeout=config.sdwebui.timeout).post(f"{config.sdwebui.api_url}sdapi/v1/txt2img",
-                                                                            json=payload)
+                                                                            json=payload, headers=self.headers)
         resp.raise_for_status()
         r = resp.json()
 
@@ -65,7 +82,7 @@ class SDWebUI(DrawingAPI):
                 payload[key] = value
 
         resp = await httpx.AsyncClient(timeout=config.sdwebui.timeout).post(f"{config.sdwebui.api_url}sdapi/v1/img2img",
-                                                                            json=payload)
+                                                                            json=payload, headers=self.headers)
         resp.raise_for_status()
         r = resp.json()
         return [Image(base64=i) for i in r.get('images', [])]


### PR DESCRIPTION
某些情况下stable diffusion api需要设置账号密码，以增强使用期间的安全性。

使用方法：
如果自己的sd api设置了账号密码，就在config文件的[sdwebui]标签下添加（注意账号和密码中间的冒号是英文的冒号）：
Authorization = 账号:密码