### PR TITLE
修复图生图init_images字段为空的bug, 过滤图生图提示词中的额外字符

### DIFF
--- a/drawing/sdwebui.py
+++ b/drawing/sdwebui.py
@@ -58,6 +58,10 @@ class SDWebUI(DrawingAPI):
         return [Image(base64=i) for i in r.get('images', [])]
 
     async def img_to_img(self, init_images: List[Image], prompt=''):
+        # 需要调用get_bytes方法，才能获取到base64字段内容
+        for x in init_images: await x.get_bytes()
+        # 消息链显示字符串中有“[图片]”字样，需要过滤
+        prompt = prompt.replace("[图片]", "")
         payload = {
             'init_images': [x.base64 for x in init_images],
             'enable_hr': 'false',


### PR DESCRIPTION
修复图生图init_images字段为空的bug
- 需要调用get_bytes方法，才能获取到base64字段内容

过滤图生图提示词中的额外字符
- 消息链显示字符串中有“[图片]”字样，需要过滤

Fixes #839