### PR TITLE
Fix response placeholder with empty message throw NameError

### DIFF
--- a/universal.py
+++ b/universal.py
@@ -78,7 +78,7 @@ async def handle_message(_respond: Callable, session_id: str, message: str,
             msg = MessageChain([Plain(msg)])
 
         nonlocal conversation_context
-        if not conversation_context:
+        if not conversation_context and conversation_handler:
             conversation_context = conversation_handler.current_conversation
 
         if not conversation_context:


### PR DESCRIPTION
error: free var 'conversation_handler' referenced before assignment in enclosing scope