### PR TITLE
Add support for new GPT 3.5 and 4 models released by OpenAI today [6/13]

### DIFF
--- a/adapter/chatgpt/api.py
+++ b/adapter/chatgpt/api.py
@@ -43,6 +43,9 @@ class ChatGPTAPIAdapter(BotAdapter):
         self.supported_models = [
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-0301",
+            "gpt-3.5-turbo-0613",
+            "gpt-3.5-turbo-16k",
+            "gpt-3.5-turbo-16k-0613",
             "gpt-4",
             "gpt-4-0314",
             "gpt-4-32k",

--- a/adapter/chatgpt/api.py
+++ b/adapter/chatgpt/api.py
@@ -50,6 +50,8 @@ class ChatGPTAPIAdapter(BotAdapter):
             "gpt-4-0314",
             "gpt-4-32k",
             "gpt-4-32k-0314",
+            "gpt-4-0613",
+            "gpt-4-32k-0613",
         ]
 
     async def switch_model(self, model_name):

--- a/config.py
+++ b/config.py
@@ -357,6 +357,9 @@ class Trigger(BaseModel):
     allowed_models: List[str] = [
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-0301",
+        "gpt-3.5-turbo-0613",
+        "gpt-3.5-turbo-16k",
+        "gpt-3.5-turbo-16k-0613",
         "text-davinci-002-render-sha",
         "text-davinci-002-render-paid"
     ]

--- a/config.py
+++ b/config.py
@@ -357,9 +357,6 @@ class Trigger(BaseModel):
     allowed_models: List[str] = [
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-0301",
-        "gpt-3.5-turbo-0613",
-        "gpt-3.5-turbo-16k",
-        "gpt-3.5-turbo-16k-0613",
         "text-davinci-002-render-sha",
         "text-davinci-002-render-paid"
     ]


### PR DESCRIPTION
Add new models released by OpenAI today:

- "gpt-3.5-turbo-0613" 
- "gpt-3.5-turbo-16k"
- "gpt-3.5-turbo-16k-0613"

- "gpt-4-0613"
- "gpt-4-32k-0613"

![image](https://github.com/lss233/chatgpt-mirai-qq-bot/assets/1166162/14e5af5e-24cd-4d27-87f4-d03dbf31014f)

![image](https://github.com/lss233/chatgpt-mirai-qq-bot/assets/1166162/fbc97a49-21fe-478d-8de1-7c794c2f6c17)

