### PR TITLE
fix: 更新 Bard 脚本以正确获取数据

### DIFF
--- a/adapter/google/bard.py
+++ b/adapter/google/bard.py
@@ -76,7 +76,7 @@ class BardAdapter(BotAdapter):
             for lines in res:
                 if "wrb.fr" in lines:
                     data = json.loads(json.loads(lines)[0][2])
-                    result = data[0][0]
+                    result = data[4][0][1][0]
                     self.bard_session_id = data[1][0]
                     self.r = data[1][1]  # 用于下一次请求, 这个位置是固定的
                     # self.rc = data[4][1][0]


### PR DESCRIPTION
## 更新 Bard 脚本以正确获取数据

### 描述
Bard 返回数据的组织方式发生了变化，脚本在读取数据时出现问题。原先代码 `result = data[0][0]` 会引发 `TypeError` 错误。分析返回数据，将代码修改为 `result = data[4][0][1][0]`可以解决问题。

修改后机器人能够正常运行。

### 附实际获取到的数据：

数据一：
```python
[None, ['c_2a0329c4aaaaaaaa', 'r_2a0329c4aaaaaaaa'],
    [
        ['Hi', 1],
        ['Why do I say hi?', 4],
        ['What is hello or hi?', 4]
], None, [
        ['rc_2a0329c4aaaaaaaa', ['Hi there! How can I help you today?'],
            [], None, None, None, True, None, None, 'en', None, None, [None, None, None, None, None, [
                []
            ]], None, False
         ]
], None, None, None, 'US'
]
```
```python
result = 'Hi there! How can I help you today?'
```

数据二：
```python
[None, ['c_e429c5f9aaaaaaaa', 'r_e429c5f9aaaaaaaa'],
    [
        ['How do you read Japanese date format?', 4],
        ['How do Japanese calculate years?', 4]
], None, [
        ['rc_f6037659aaaaaaaa', ["Alright, I'm all ears. What would you like to ask me?"],
            [], None, None, None, True, None, None, 'en', None, None, [None, None, None, None, None, [
                []
            ]], None, False
         ],
        ['rc_f6037659aaaaaaaa', ['Great! What can I help you with today?'],
            [], None, None, None, True, None, None, 'en', None, None, [None, None, None, None, None, [
                []
            ]], None, False
         ],
        ['rc_f6037659aaaaaaaa', ['Great. What can I help you with today?'],
            [], None, None, None, True, None, None, 'en', None, None, [None, None, None, None, None, [
                []
            ]], None, False
         ]
], None, None, None, 'JP'
]
```
```python
result = "Alright, I'm all ears. What would you like to ask me?"
```