### PR TITLE
更新edgeGPT

### DIFF
--- a/adapter/ms/bing.py
+++ b/adapter/ms/bing.py
@@ -9,14 +9,14 @@ from PIL import Image
 
 from constants import config
 from adapter.botservice import BotAdapter
-from EdgeGPT import Chatbot as EdgeChatbot, ConversationStyle, NotAllowedToAccess
+from EdgeGPT.EdgeGPT import Chatbot as EdgeChatbot, ConversationStyle, NotAllowedToAccess
 from contextlib import suppress
 
 from constants import botManager
 from drawing import DrawingAPI
 from exceptions import BotOperationNotSupportedException
 from loguru import logger
-from ImageGen import ImageGenAsync
+from EdgeGPT.ImageGen import ImageGenAsync
 from graia.ariadne.message.element import Image as GraiaImage
 
 image_pattern = r"!\[.*\]\((.*)\)"

--- a/conversation.py
+++ b/conversation.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import List, Dict, Optional
 
 import httpx
-from EdgeGPT import ConversationStyle
+from EdgeGPT.EdgeGPT import ConversationStyle
 from graia.amnesia.message import MessageChain
 from graia.ariadne.message.element import Image as GraiaImage, Element
 from loguru import logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pygments~=2.15.1
 imgkit~=1.2.3
 qrcode~=7.4.2
 openai~=0.27.8
-EdgeGPT==0.8.2
+EdgeGPT==0.12.1
 aiohttp~=3.8.4
 OpenAIAuth
 urllib3~=1.26.15


### PR DESCRIPTION
现在包里用的edgeGPT 是0.8 ，而官方库已经到0.12了。现在更新了一下依赖和部分实现的代码。
主要是包引用问题。其他没改。

经测试，聊天和画图正常