### PR TITLE
完善了删除过期额度的方案，避免第二天继承上一天没使用完的额度

### DIFF
--- a/manager/ratelimit.py
+++ b/manager/ratelimit.py
@@ -62,7 +62,7 @@ class RateLimitManager:
 
         # 初始化
         if usage is None:
-            usage = {'type': _type, 'id': _id, 'count': 0, 'time': current_time}
+            usage = {'type': _type, 'id': _id, 'count': 0, 'time': current_time, 'day': current_day}
             self.draw_usage_db.insert(usage)
 
         return usage
@@ -73,15 +73,18 @@ class RateLimitManager:
         q = Query()
         usage = self.usage_db.get(q.fragment({"type": _type, "id": _id}))
         current_time = time.localtime(time.time()).tm_hour
+        current_day = time.localtime(time.time()).tm_mday
 
         # 删除过期的记录
-        if usage is not None and usage['time'] != current_time:
+        time_diff_dondition = (usage is not None and usage['time'] != current_time)
+        day_diff_condition = (usage is not None and usage['time'] == current_time and usage['day'] != current_day)
+        if time_diff_dondition or day_diff_condition:
             self.usage_db.remove(doc_ids=[usage.doc_id])
             usage = None
-
+            
         # 初始化
         if usage is None:
-            usage = {'type': _type, 'id': _id, 'count': 0, 'time': current_time}
+            usage = {'type': _type, 'id': _id, 'count': 0, 'time': current_time, 'day': current_day}
             self.usage_db.insert(usage)
 
         return usage


### PR DESCRIPTION
前段时间给用户使用的过程中发现一个问题（我设置所有用户的额度为20条/小时），如果某用户第一天晚上八点时对话了18条，且九点后一直到次日八点这个用户没有继续进行对话，那么第二天八点时，该用户将继承这个18/20的使用额度，导致该用户在今天八点时只能对话2条。因此对于`chatgpt-mirai-qq-bot/manager/ratelimit.py`函数进行修改：
- 在rate_usage.json数据库中，记录`day`的属性。初始化时，`usage = {'type': _type, 'id': _id, 'count': 0, 'time': current_time, 'day': current_day}`
- 在`get_usage`函数中，添加了根据天数`day`删除过期的记录的判断方案。