### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ Quart==0.17.0
 pydub~=0.25.1
 httpcore~=0.17.3
 g4f~=0.0.2.6
+creart


### PR DESCRIPTION
最新的docker缺module，运行不起来
```
docker logs chatgpt-chatgpt-1 -f
Traceback (most recent call last):
  File "/app/bot.py", line 9, in <module>
    import creart
ModuleNotFoundError: No module named 'creart'
(EE)
Fatal server error:
(EE) Server is already active for display 0
        If this server is no longer running, remove /tmp/.X0-lock
        and start again.
(EE)
Traceback (most recent call last):
  File "/app/bot.py", line 9, in <module>
    import creart
ModuleNotFoundError: No module named 'creart'
(EE)
Fatal server error:
(EE) Server is already active for display 0
        If this server is no longer running, remove /tmp/.X0-lock
        and start again.
(EE)
```