### PR TITLE
暂时抑制用户发送空消息时关于未定义conversation_handler的报错（转至log报错）

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,9 @@ loop.run_until_complete(botManager.login())
 
 bots = []
 
+# 将log输出到stdout
+logger.configure(handlers=[{"sink": sys.stdout}])
+
 if config.mirai:
     logger.info("检测到 mirai 配置，将启动 mirai 模式……")
     from platforms.ariadne_bot import start_task

--- a/config.py
+++ b/config.py
@@ -517,6 +517,12 @@ class Ratelimit(BaseModel):
 
 
 class SDWebUI(BaseModel):
+    class ScriptArg(BaseModel):
+        ad_model: str
+
+    class ScriptConfig(BaseModel):
+        args: List['SDWebUI.ScriptArg']
+    
     api_url: str
     """API 基地址，如：http://127.0.0.1:7890"""
     prompt_prefix: str = 'masterpiece, best quality, illustration, extremely detailed 8K wallpaper'
@@ -534,6 +540,7 @@ class SDWebUI(BaseModel):
     cfg_scale: float = 7.5
     restore_faces: bool = False
     authorization: str = ''
+    alwayson_scripts: Dict[str, 'SDWebUI.ScriptConfig'] = {}
     """登录api的账号:密码"""
 
     timeout: float = 10.0
@@ -541,6 +548,8 @@ class SDWebUI(BaseModel):
 
     class Config(BaseConfig):
         extra = Extra.allow
+SDWebUI.update_forward_refs()
+SDWebUI.ScriptConfig.update_forward_refs()
 
 
 class Config(BaseModel):

--- a/conversation.py
+++ b/conversation.py
@@ -235,7 +235,9 @@ class ConversationContext:
                                                                                   text.strip())
                         logger.debug(f"Set conversation voice to {self.conversation_voice.full_name}")
                         continue
-
+                    
+                    # Replace {date} in system prompt
+                    text = text.replace("{date}", datetime.now().strftime('%Y-%m-%d'))
                     async for item in self.adapter.preset_ask(role=role.lower().strip(), text=text.strip()):
                         yield item
         elif keyword != 'default':

--- a/conversation.py
+++ b/conversation.py
@@ -153,6 +153,9 @@ class ConversationContext:
         await self.adapter.on_reset()
         self.last_resp = ''
         self.last_resp_time = -1
+        # 在重置会话时自动加载默认预设
+        async for value in self.load_preset('default'):
+            pass
         yield config.response.reset
 
     @retry((httpx.ConnectError, httpx.ConnectTimeout, TimeoutError))

--- a/drawing/sdwebui.py
+++ b/drawing/sdwebui.py
@@ -41,7 +41,8 @@ class SDWebUI(DrawingAPI):
             'tiling': 'false',
             'negative_prompt': config.sdwebui.negative_prompt,
             'eta': 0,
-            'sampler_index': config.sdwebui.sampler_index
+            'sampler_index': config.sdwebui.sampler_index,
+            'alwayson_scripts': {}
         }
 
         for key, value in config.sdwebui.dict(exclude_none=True).items():

--- a/universal.py
+++ b/universal.py
@@ -79,7 +79,10 @@ async def handle_message(_respond: Callable, session_id: str, message: str,
 
         nonlocal conversation_context
         if not conversation_context:
-            conversation_context = conversation_handler.current_conversation
+            try:
+                conversation_context = conversation_handler.current_conversation
+            except NameError:
+                logger.warning(f"收到空消息时尚未定义conversation_handler，报错已忽略")
 
         if not conversation_context:
             return ret


### PR DESCRIPTION
fixes #1306 in a sketchy way