### PR TITLE
fix(plugins.deepseek_adapter): 修复导包错误

### DIFF
--- a/plugins/deepseek_adapter/__init__.py
+++ b/plugins/deepseek_adapter/__init__.py
@@ -3,7 +3,7 @@ from framework.im.telegram.config import TelegramConfig
 from framework.llm.llm_registry import LLMAbility
 from framework.logger import get_logger
 from framework.plugin_manager.plugin import Plugin
-from deepseek_adapter.adapter import DeepSeekAdapter, DeepSeekConfig
+from plugins.deepseek_adapter.adapter import DeepSeekAdapter, DeepSeekConfig
 
 logger = get_logger("DeepSeek")
 class DeepSeekPlugin(Plugin):


### PR DESCRIPTION
采用仓库根路径的方式修复导包错误

Fixes #1383

## Summary by Sourcery

修复 DeepSeek 适配器的导入路径。

Bug 修复：
- 修复 DeepSeek 适配器的导入错误。

日常维护：
- 将导入路径更新为相对于仓库根目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix import path for the DeepSeek adapter.

Bug Fixes:
- Fix import error for the DeepSeek adapter.

Chores:
- Update the import path to be relative to the repository root.

</details>