### PR TITLE
fix: Add default web configuration in Docker startup script

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -17,4 +17,15 @@ if [ -z "$(ls -A /app/data)" ]; then
     cp -r /tmp/data /app/data
 fi
 
+# create default config
+if [ ! -f "/app/data/config.yaml" ]; then
+    echo "Config file does not exist, creating..."
+    # 必须配置 web，否则无法访问
+    cat <<EOF > /app/data/config.yaml
+web:
+    host: 0.0.0.0
+    port: 8080
+EOF
+fi
+
 python -m kirara_ai


### PR DESCRIPTION
Automatically create a default config.yaml with web host and port settings if no configuration exists, ensuring the application can be accessed by default

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

如果 Docker 镜像中不存在默认配置文件，则添加一个。 这确保了默认情况下可以访问 Web 界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a default configuration file to the Docker image if one does not exist. This ensures the web interface is accessible by default.

</details>