### PR TITLE
fix: Correct send message logic in HTTP Legacy Adapter

### DIFF
--- a/kirara_ai/im/sender.py
+++ b/kirara_ai/im/sender.py
@@ -31,6 +31,7 @@ class ChatSender:
     chat_type: ChatType
     group_id: Optional[str] = None
     raw_metadata: Dict[str, Any] = None
+    callback = None
     
     @classmethod
     def from_group_chat(

--- a/kirara_ai/plugins/im_http_legacy_adapter/adapter.py
+++ b/kirara_ai/plugins/im_http_legacy_adapter/adapter.py
@@ -57,15 +57,6 @@ class MessageHandler(Protocol):
     async def __call__(self, message: IMMessage) -> None: ...
 
 
-class Sender:
-    def __init__(self, username: str, callback: MessageHandler):
-        self.username = username
-        self.callback = callback
-
-    async def __call__(self, message: IMMessage):
-        await self.callback(message)
-
-
 class V2Request:
     def __init__(self, session_id: str, username: str, message: str, request_time: str):
         self.session_id = session_id
@@ -147,7 +138,7 @@ class HttpLegacyAdapter(IMAdapter):
 
             bot_request = V2Request(
                 session_id,
-                message.sender.username,
+                message.sender.display_name,
                 data.get("message", ""),
                 request_time,
             )
@@ -185,8 +176,8 @@ class HttpLegacyAdapter(IMAdapter):
 
     async def send_message(self, message: IMMessage, recipient: Any):
         """此处负责 HTTP 的响应逻辑"""
-        if isinstance(recipient, Sender):
-            await recipient(message)
+        if isinstance(recipient, ChatSender):
+            await recipient.callback(message)
 
     async def start(self):
         """启动HTTP服务器"""


### PR DESCRIPTION
- Add a callback attribute to ChatSender.
- Remove redundant Sender and replace its usage with ChatSender.

https://github.com/lss233/chatgpt-mirai-qq-bot/issues/1418

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 HTTP Legacy Adapter，直接使用 ChatSender 发送消息，移除冗余的 Sender 类，并向 ChatSender 添加回调属性。

增强功能：
- 使用 ChatSender 替换自定义的 Sender 类，以简化消息发送。
- 向 ChatSender 添加回调属性以处理消息传递。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactors the HTTP Legacy Adapter to use ChatSender directly for sending messages, removing the redundant Sender class and adding a callback attribute to ChatSender.

Enhancements:
- Replaces the custom Sender class with ChatSender to streamline message sending.
- Adds a callback attribute to ChatSender to handle message delivery.

</details>